### PR TITLE
fix wrong exit code when $newBoot is not set

### DIFF
--- a/files/usr/local/sbin/pi-boot-switch
+++ b/files/usr/local/sbin/pi-boot-switch
@@ -818,7 +818,7 @@ else
     doInstall || exit 3
   fi
   [ -n "$switch" ]      && doSwitch
-  [ -n "$newBoot" ]     && doNewBoot
+  [ ! -z "$newBoot" ]     && doNewBoot
   [ -n "$label" ]       && doLabel
   [ -n "$description" ] && doDescription
   [ -n "$reboot" ]      && doReboot

--- a/files/usr/local/sbin/pi-boot-switch
+++ b/files/usr/local/sbin/pi-boot-switch
@@ -818,8 +818,10 @@ else
     doInstall || exit 3
   fi
   [ -n "$switch" ]      && doSwitch
-  [ ! -z "$newBoot" ]     && doNewBoot
+  [ -n "$newBoot" ]     && doNewBoot
   [ -n "$label" ]       && doLabel
   [ -n "$description" ] && doDescription
   [ -n "$reboot" ]      && doReboot
 fi
+
+exit 0


### PR DESCRIPTION
When `$newBoot `is not enabled via `-B`, the exit code will always be `>0`.

### Background

`[ -n "$newBoot" ]` has the exit code _1_ when the string is empty.

```
pi@raspberry:~ $ var=""
pi@raspberry:~ $ [ -n "$var" ] && echo "var is $var"
pi@raspberry:~ $ echo $?
1
pi@raspberry:~ $ [ ! -z "$var" ] && echo "var is $var"
pi@raspberry:~ $ echo $?
1
pi@raspberry:~ $ var="testing"
pi@raspberry:~ $ [ ! -z "$var" ] && echo "var is $var"
var is testing
pi@raspberry:~ $ echo $?
0
pi@raspberry:~ $
```
