### PR TITLE
#6 Fix getting current boot device on Debian bookworm

### DIFF
--- a/files/usr/local/sbin/pi-boot-switch
+++ b/files/usr/local/sbin/pi-boot-switch
@@ -289,7 +289,7 @@ doInfo() {
 
   # fetch current roles of partitions
   local currentRoot=$(getCurrentDevice NAME /)
-  local currentBoot=$(getCurrentDevice NAME /boot)
+  local currentBoot=$(getCurrentDevice NAME /boot || getCurrentDevice NAME /boot/firmware)
   local nextRoot=$(getNextRootDevice)
 
   role[$currentRoot]="curr root"


### PR DESCRIPTION
This is a naive and quick fix for https://github.com/bablokb/pi-boot-switch/issues/6
If there is no `/boot` mount found, try `/boot/firmware`